### PR TITLE
Fix authentication issues when doing dotnet restore in actions

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,7 @@
 <configuration>
     <packageSources>
         <clear />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
         <add key="github" value="https://nuget.pkg.github.com/OWNER/index.json" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
- GitHub repo requires authentication, Nuget.org doesn't.